### PR TITLE
Add note to add ckan.lo to hosts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ In order to make the getting started part easier I created this shell script to 
 4. Move to the directory with your terminal application `cd ckan-vagrant/`
 5. Create the instance `vagrant up`
 6. Go get some coffee (it takes up to 15 minutes)
-7. Open [http://ckan.lo](http://ckan.lo) in your browser.
+7. Add to following line to `/etc/hosts`:  `192.168.19.97 ckan.lo`
+8. Open [http://ckan.lo](http://ckan.lo) in your browser.
 	
 
 ## License


### PR DESCRIPTION
Just to make sure this works for everybody: you need to explicitly add ckan.lo to your hosts file in order to be able to access http://ckan.lo on your machine when starting the vagrant box.
