### PR TITLE
fixed ckan package name in provision script

### DIFF
--- a/vagrant/package_provision.sh
+++ b/vagrant/package_provision.sh
@@ -12,10 +12,10 @@ echo "installing dependencies available via apt-get"
 sudo apt-get install -y nginx apache2 libapache2-mod-wsgi libpq5
 
 echo "downloading the CKAN package"
-wget -q http://packaging.ckan.org/python-ckan-2.0_amd64.deb
+wget -q http://packaging.ckan.org/python-ckan_2.0_amd64.deb
 
 echo "installing the CKAN package"
-sudo dpkg -i python-ckan-2.0_amd64.deb
+sudo dpkg -i python-ckan_2.0_amd64.deb
 
 echo "Preventing NGINX from being started on a reboot"
 sudo update-rc.d -f nginx disable
@@ -23,7 +23,7 @@ sudo update-rc.d -f nginx disable
 echo "changing the apache configuration back to port 80"
 sudo cp /vagrant/vagrant/package_ports.conf /etc/apache2/ports.conf
 sudo cp /vagrant/vagrant/package_ckan_default.conf /etc/apache2/sites-available/ckan_default
-sudo service apache2 restart 
+sudo service apache2 restart
 
 echo "install postgresql and jetty"
 sudo apt-get install -y postgresql solr-jetty openjdk-6-jdk


### PR DESCRIPTION
CKAN package wan't being installed, presuming the package names have changed on http://packaging.ckan.org/. Changing to python-ckan_2.0_amd64.deb fixed issue.